### PR TITLE
Fix alternative for major version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ The following transient branches also exist:
 
 ## General flow
   * Code has been submitted to the ``develop`` branch, probably through pull requests from feature branches
-  * When the next version is ready to be released, run ``release-tools create-cand <owner> <repo>``
-  * This creates a new release branch called ``release-#.#.#``, where the minor version has 
+  * When the next version is ready to be released, run ``release-tools create-cand <owner> <repo> [--major]``
+  * This creates a new release branch called ``release-#.#.#``, where the minor or major version has 
     been increased, e.g. 1.0.2 -> 1.1.0.
   * Build and validate (separate workflow). Latest version can be fetched with
   ``release-tools download <owner> <repo> <path>``. Deploy if it passes the QA process.

--- a/release_tools/cli.py
+++ b/release_tools/cli.py
@@ -30,11 +30,12 @@ def cli(ctx, whatif, config):
 @cli.command('create-cand')
 @click.argument('owner')
 @click.argument('repo')
+@click.option('--major', is_flag=True)
 @click.pass_context
-def create_cand(ctx, owner, repo):
+def create_cand(ctx, owner, repo, major):
     print "Creating a release candidate from {}".format(DEVELOP_BRANCH)
     workflow = create_workflow(owner, repo, ctx.obj['whatif'], ctx.obj['config'])
-    workflow.create_release_candidate()
+    workflow.create_release_candidate(major_inc=major)
 
 
 @cli.command('create-hotfix')

--- a/release_tools/workflow.py
+++ b/release_tools/workflow.py
@@ -29,21 +29,22 @@ class Workflow:
         tag_name = self.provider.get_latest_version_tag_name()
         return self.conventions.get_version_from_tag(tag_name)
 
-    def get_candidate_version(self):
-        return self.get_latest_version().inc_minor()
+    def get_candidate_version(self, major_inc=False):
+        return self.get_latest_version().inc_major() if major_inc \
+            else self.get_latest_version().inc_minor()
 
     def get_hotfix_version(self):
         return self.get_latest_version().inc_patch()
 
-    def get_candidate_branch(self):
-        version = self.get_candidate_version()
+    def get_candidate_branch(self, major_inc=False):
+        version = self.get_candidate_version(major_inc=major_inc)
         return self.conventions.get_branch_name_from_version(version, RELEASE_BRANCH_PRE)
 
     def get_hotfix_branch(self):
         version = self.get_hotfix_version()
         return self.conventions.get_branch_name_from_version(version, HOTFIX_BRANCH_PRE)
 
-    def create_release_candidate(self):
+    def create_release_candidate(self, major_inc=False):
         """
         Pre: The master branch has a tagged latest version (TODO: Support if it hasn't)
 
@@ -54,7 +55,7 @@ class Workflow:
         The next step is to create a pull request from develop to the new release branch.
         This branch should then be code reviewed and eventually merged.
         """
-        candidate_branch = self.get_candidate_branch()
+        candidate_branch = self.get_candidate_branch(major_inc=major_inc)
 
         print "Creating a new branch, '{}' from master".format(candidate_branch)
         if not self.whatif:


### PR DESCRIPTION
Add flag --major to the create-cand command.

This is tested on a test repo on git, with the commands create-cand,
download and accept, in this order. The download and accept commands
don't need the --major input, since they are searching for the next
release branch on git.