### PR TITLE
Bug fix for returning pending release branches

### DIFF
--- a/release_tools/workflow.py
+++ b/release_tools/workflow.py
@@ -124,8 +124,10 @@ class Workflow:
     def get_pending_release_branches(self, current_tag, branch_names):
         for branch in self.get_release_branches(branch_names):
             branch_version = Version.from_string(branch.split("-")[1])
-            if branch_version[0] > current_tag[0] or \
-               branch_version[1] > current_tag[1]:
+            if branch_version[0] > current_tag[0]:
+                yield branch
+            elif branch_version[0] == current_tag[0] and \
+                 branch_version[1] > current_tag[1]:
                 yield branch
 
     def get_queue(self):


### PR DESCRIPTION
The bugfix concerns this situation:

* There have been a major release, current version = 2.0.0
* There is an old release branch with version number 1.1.0

With the curent implementation, the old release branch 1.1.0 will be
put in the release queue as a pending release, which is wrong.