### PR TITLE
Fix string encoding and line endings

### DIFF
--- a/release_tools/github.py
+++ b/release_tools/github.py
@@ -105,8 +105,10 @@ class GithubProvider:
     def _release_history_contents(self, json):
         c = []
         for release in json:
-            d = dateutil.parser.parse(release['published_at'])
-            c.append("{}, {:%Y-%m-%d}\n\n{}".format(release['name'], d, release['body']))
+            d = dateutil.parser.parse(release['published_at'].encode('utf-8'))
+            release_name = release['name'].encode('utf-8')
+            release_body = release['body'].encode('utf-8')
+            c.append("{}, {:%Y-%m-%d}\n\n{}".format(release_name, d, release_body))
         return str.join('\n\n\n', c)
 
     def get_branches(self):

--- a/release_tools/github.py
+++ b/release_tools/github.py
@@ -108,6 +108,7 @@ class GithubProvider:
             d = dateutil.parser.parse(release['published_at'].encode('utf-8'))
             release_name = release['name'].encode('utf-8')
             release_body = release['body'].encode('utf-8')
+            release_body = '\n'.join(release_body.splitlines())
             c.append("{}, {:%Y-%m-%d}\n\n{}".format(release_name, d, release_body))
         return str.join('\n\n\n', c)
 


### PR DESCRIPTION
At download-release-history:

Fix line endings so that they are converted to platform specific line endings. 

Do explicit encoding to utf-8 to avoid runtime error (UnicodeEncodingError)
